### PR TITLE
Move the frontend logger to a separate file

### DIFF
--- a/build/frontend.js
+++ b/build/frontend.js
@@ -1,0 +1,34 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+function FrontEndLogger() {
+  this.isFrontEnd = true;
+  this.info = console.log.bind(console); // eslint-disable-line no-console
+  this.error = function proxyError() {
+    var _console;
+
+    if (typeof Rollbar !== 'undefined' && typeof Rollbar.error === 'function') {
+      var _Rollbar;
+
+      (_Rollbar = Rollbar).error.apply(_Rollbar, arguments);
+    }
+
+    (_console = console).error.apply(_console, arguments); // eslint-disable-line no-console
+  };
+  this.warn = function proxyWarn() {
+    var _console2;
+
+    if (typeof Rollbar !== 'undefined' && typeof Rollbar.warning === 'function') {
+      var _Rollbar2;
+
+      (_Rollbar2 = Rollbar).warning.apply(_Rollbar2, arguments);
+    }
+
+    (_console2 = console).warn.apply(_console2, arguments); // eslint-disable-line no-console
+  };
+  this.trace = console.trace.bind(console); // eslint-disable-line no-console
+}
+
+exports.default = FrontEndLogger;

--- a/build/logger.js
+++ b/build/logger.js
@@ -12,43 +12,17 @@ var _stdIOStream = require('./stdIOStream');
 
 var _stdIOStream2 = _interopRequireDefault(_stdIOStream);
 
+var _frontend = require('./frontend');
+
+var _frontend2 = _interopRequireDefault(_frontend);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-/* global Rollbar */
-
-var logLevel = process.env.LOG_LEVEL || 'info';
-
-function FrontEndLogger() {
-  this.isFrontEnd = true;
-  this.info = console.log.bind(console); // eslint-disable-line no-console
-  this.error = function proxyError() {
-    var _console;
-
-    if (typeof Rollbar !== 'undefined' && typeof Rollbar.error === 'function') {
-      var _Rollbar;
-
-      (_Rollbar = Rollbar).error.apply(_Rollbar, arguments);
-    }
-
-    (_console = console).error.apply(_console, arguments); // eslint-disable-line no-console
-  };
-  this.warn = function proxyWarn() {
-    var _console2;
-
-    if (typeof Rollbar !== 'undefined' && typeof Rollbar.warning === 'function') {
-      var _Rollbar2;
-
-      (_Rollbar2 = Rollbar).warning.apply(_Rollbar2, arguments);
-    }
-
-    (_console2 = console).warn.apply(_console2, arguments); // eslint-disable-line no-console
-  };
-  this.trace = console.trace.bind(console); // eslint-disable-line no-console
-}
+var logLevel = process.env.LOG_LEVEL || 'info'; /* global Rollbar */
 
 exports.default = function logger() {
   if (typeof window !== 'undefined') {
-    return new FrontEndLogger();
+    return new _frontend2.default();
   }
   var runningScript = require.main.filename.split('/').pop();
   var streams = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hodlog",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Zoover",
   "main": "./build/index.js",
   "scripts": {

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -1,0 +1,21 @@
+function FrontEndLogger() {
+  this.isFrontEnd = true;
+  this.info = console.log.bind(console); // eslint-disable-line no-console
+  this.error = function proxyError(...args) {
+    if (typeof Rollbar !== 'undefined' && typeof Rollbar.error === 'function') {
+      Rollbar.error(...args);
+    }
+
+    console.error(...args); // eslint-disable-line no-console
+  };
+  this.warn = function proxyWarn(...args) {
+    if (typeof Rollbar !== 'undefined' && typeof Rollbar.warning === 'function') {
+      Rollbar.warning(...args);
+    }
+
+    console.warn(...args); // eslint-disable-line no-console
+  };
+  this.trace = console.trace.bind(console); // eslint-disable-line no-console
+}
+
+export default FrontEndLogger;

--- a/src/logger.js
+++ b/src/logger.js
@@ -2,28 +2,9 @@
 
 import bunyan from 'bunyan';
 import stdIOStream from './stdIOStream';
+import FrontEndLogger from './frontend';
 
 const logLevel = process.env.LOG_LEVEL || 'info';
-
-function FrontEndLogger() {
-  this.isFrontEnd = true;
-  this.info = console.log.bind(console); // eslint-disable-line no-console
-  this.error = function proxyError(...args) {
-    if (typeof Rollbar !== 'undefined' && typeof Rollbar.error === 'function') {
-      Rollbar.error(...args);
-    }
-
-    console.error(...args); // eslint-disable-line no-console
-  };
-  this.warn = function proxyWarn(...args) {
-    if (typeof Rollbar !== 'undefined' && typeof Rollbar.warning === 'function') {
-      Rollbar.warning(...args);
-    }
-
-    console.warn(...args); // eslint-disable-line no-console
-  };
-  this.trace = console.trace.bind(console); // eslint-disable-line no-console
-}
 
 export default (function logger() {
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
Currently, when importing `hodlog`, it imports `bunyan`, which we don't
need when we're in the browser.

This change moves the frontend logger to its own file, so we can import
only that file when we're running the client, and bunyan won't end up in
the browser bundle.